### PR TITLE
Set THEME_DARK as default to align with default selection of Colors (Dark)

### DIFF
--- a/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
+++ b/app/src/main/java/helium314/keyboard/latin/settings/Settings.java
@@ -615,7 +615,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
         boolean isNight = ResourceUtils.isNight(context.getResources());
         if (ColorsSettingsFragment.Companion.getForceOppositeTheme()) isNight = !isNight;
         final String themeColors = (isNight && readDayNightPref(prefs, context.getResources()))
-                ? prefs.getString(Settings.PREF_THEME_COLORS_NIGHT, KeyboardTheme.THEME_DARKER)
+                ? prefs.getString(Settings.PREF_THEME_COLORS_NIGHT, KeyboardTheme.THEME_DARK)
                 : prefs.getString(Settings.PREF_THEME_COLORS, KeyboardTheme.THEME_LIGHT);
         final String themeStyle = prefs.getString(Settings.PREF_THEME_STYLE, KeyboardTheme.STYLE_MATERIAL);
 


### PR DESCRIPTION
THEME_DARK is the first on the list of [COLORS_DARK](https://github.com/Helium314/HeliBoard/blob/77cdf4884644fc8ebd59a85ac9e1ae95c8ccccdd/app/src/main/java/helium314/keyboard/keyboard/KeyboardTheme.kt#L63) for material, so it is selected by default. Now, the default theme will match the untweaked Colors (Dark) selection.